### PR TITLE
PHP Strict Standards:  Only variables should be passed by reference

### DIFF
--- a/p2-resolved-posts.php
+++ b/p2-resolved-posts.php
@@ -216,7 +216,9 @@ class P2_Resolved_Posts {
 	 * Given a slug, get the state
 	 */
 	function get_state( $slug ) {
-		return array_shift( wp_filter_object_list( $this->states, array( 'slug' => $slug ) ) );
+
+		$filtered_states = wp_filter_object_list( $this->states, array( 'slug' => $slug ) );
+		return array_shift( $filtered_states );
 	}
 
 	/**


### PR DESCRIPTION
PHP Strict Standards:  Only variables should be passed by reference in /srv/www/hmn.dev/content/plugins/p2-resolved-posts/p2-resolved-posts.php on line 219

@willmot R/M please